### PR TITLE
Call dpa_check and dea_check in the path

### DIFF
--- a/packages/dea_check/test_regress.sh
+++ b/packages/dea_check/test_regress.sh
@@ -1,4 +1,4 @@
-python /proj/sot/ska/share/dea/dea_check.py \
+dea_check \
    --outdir=out \
    --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
    --run-start=2013:031

--- a/packages/dpa_check/test_regress.sh
+++ b/packages/dpa_check/test_regress.sh
@@ -1,4 +1,4 @@
-python /proj/sot/ska/share/dpa/dpa_check.py \
+dpa_check \
    --outdir=out \
    --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
    --run-start=2013:031


### PR DESCRIPTION
Now that dpa_check and dea_check are installed modules with entry-point scripts
and entries in /proj/sot/ska/bin.  These changes in the regress tests calls
should call either script in the path.