### PR TITLE
Fix critical bug in eng_archive regression test and improve workflow

### DIFF
--- a/packages/Ska.engarchive/test_make_archive_long.sh
+++ b/packages/Ska.engarchive/test_make_archive_long.sh
@@ -3,9 +3,11 @@
 GIT=`PATH=/usr/bin:$PATH which git`
 $GIT clone ${TESTR_PACKAGES_REPO}/eng_archive
 cd eng_archive
-git checkout master
-cp update_archive.py add_derived.py archfiles_def.sql ../
-cd ../
+
+# Checkout test branch, either ENG_ARCHIVE_BRANCH env var or master.
+# Google "bash parameter expansion" for this syntax.
+git checkout ${ENG_ARCHIVE_BRANCH:-master}
+
 mkdir data
 
 CONTENTS="--content=acis2eng --content=acis3eng --content=acisdeahk --content=simcoor --content=orbitephem0"
@@ -37,4 +39,4 @@ echo "Creating archive stats..."
 
 # Compare newly created values to flight
 echo "Comparing newly created values to flight"
-./compare_values.py --start=$START --stop=$STOP $CONTENTS
+../compare_values.py --start=$START --stop=$STOP $CONTENTS


### PR DESCRIPTION
The eng_archive update_archive regression testing was actually always just running from the installed version and not actually testing the local branch.  (!!)  This is because the `./update_archive.py` call was being done from a directory where the local `Ska.engarchive` is not in the path (recall that PYTHONPATH is useless to help here).  This PR fixes this to run from within the repo.

One checks this by looking at the logging output and seeing the file name for the `update_archive` module.  (I went looking for this as a result of having noticed this during the jSka hangout).

Yet another negative consequence of namespace packages, sigh.

This PR also introduces an environment variable `ENG_ARCHIVE_BRANCH` which, if set, will set the branch that gets checked out.  Without this env var set it will check out `master`.
