### PR TITLE
Update ACIS checker tests

### DIFF
--- a/packages/acisfp_check/post_check_logs.py
+++ b/packages/acisfp_check/post_check_logs.py
@@ -1,3 +1,6 @@
 from testr.packages import check_files
 
-check_files('test_*.log', ['warning', 'error'])
+check_files('test_*.log', ['warning', 'error'],
+            allows=['1% quantile value of',
+                    '99% quantile value of',
+                    'in output at out'])

--- a/packages/acisfp_check/test_regress.sh
+++ b/packages/acisfp_check/test_regress.sh
@@ -1,4 +1,4 @@
-python /proj/sot/ska/share/acisfp/acisfp_check.py \
+acisfp_check \
    --outdir=out \
-   --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
-   --run-start=2013:031
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142

--- a/packages/dea_check/post_check_logs.py
+++ b/packages/dea_check/post_check_logs.py
@@ -1,4 +1,6 @@
 from testr.packages import check_files
 
 check_files('test_*.log', ['warning', 'error'],
-            allows=['99% quantile value of', 'in output at out'])
+            allows=['1% quantile value of',
+                    '99% quantile value of',
+                    'in output at out'])

--- a/packages/dea_check/test_regress.sh
+++ b/packages/dea_check/test_regress.sh
@@ -1,4 +1,4 @@
 dea_check \
    --outdir=out \
-   --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
-   --run-start=2013:031
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142

--- a/packages/dpa_check/post_check_logs.py
+++ b/packages/dpa_check/post_check_logs.py
@@ -1,4 +1,8 @@
 from testr.packages import check_files
 
 check_files('test_*.log', ['warning', 'error'],
-            allows=['99% quantile value of', 'in output at out'])
+            allows=['1% quantile value of',
+                    '1dpamzt violates planning limit of 35.50 deg',
+                    '50% quantile value of',
+                    '99% quantile value of',
+                    'in output at out'])

--- a/packages/dpa_check/test_regress.sh
+++ b/packages/dpa_check/test_regress.sh
@@ -1,4 +1,4 @@
 dpa_check \
    --outdir=out \
-   --oflsdir=/data/mpcrit1/mplogs/2013/FEB0413/oflsa \
-   --run-start=2013:031
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142


### PR DESCRIPTION
These use the newer ACIS state builder by default, work only on
newer directories, and should be run out of the ACIS load review area.