### PR TITLE
Ignore some more (expected) warnings

### DIFF
--- a/packages/chandra_aca/post_check_logs.py
+++ b/packages/chandra_aca/post_check_logs.py
@@ -1,3 +1,5 @@
 from testr.packages import check_files
 
-check_files('test_*.log', ['warning', 'error'])
+check_files('test_*.log', ['warning', 'error'],
+            allows=['using `oa_ndim == 0` when `op_axes` is NULL is deprecated.',
+                    'mica.archive.aca_dark.dark_model is deprecated.'])

--- a/packages/mica/post_check_logs.py
+++ b/packages/mica/post_check_logs.py
@@ -3,4 +3,5 @@ from testr.packages import check_files
 check_files('test_*.log', ['warning', 'error'],
             allows=['did not parse as fits unit',
                     'specified but multiple tables',
-                    'has 2 aspect intervals'])
+                    'has 2 aspect intervals'
+                    'NaturalNameWarning:'])


### PR DESCRIPTION
Ignore a Deprecation warning in chandra_aca and a NaturalNaming  warning from mica.