### PR TITLE
Update starcheck and acis regress outputs

### DIFF
--- a/get_version_id
+++ b/get_version_id
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo `ska_version`_`uname -i`_${HOSTNAME}
+echo `ska_version`_`uname -s`_`uname -m`_${HOSTNAME}
 

--- a/packages/acisfp_check/post_check_logs.py
+++ b/packages/acisfp_check/post_check_logs.py
@@ -3,5 +3,8 @@ from testr.packages import check_files
 check_files('test_*.log', ['warning', 'error'],
             allows=['1% quantile value of',
                     '99% quantile value of',
-                    'in output at out',
-                    'AstropyDeprecationWarning: out/states.dat already exists.'])
+                    'validation warning\(s\) in output',
+                    'fptemp violates ACIS-I limit',
+                    'fptemp violates FP-sensitive limit',
+                    'AstropyDeprecationWarning: out/states.dat already exists.',
+                    'AstropyDeprecationWarning: headout/states.dat already exists.'])

--- a/packages/acisfp_check/post_regress.py
+++ b/packages/acisfp_check/post_regress.py
@@ -6,8 +6,9 @@ regress_files = ['out/index.rst',
                  'out/states.dat',
                  'out/temperatures.dat']
 
-clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', ''),
+clean = {'out/index.rst': [(r'^Run time.*', ''),
+                           ('Load directory.*', '')],
+         'out/run.dat': [(r'#.*run at.*', ''),
                          (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/acisfp_check/post_regress.py
+++ b/packages/acisfp_check/post_regress.py
@@ -1,3 +1,4 @@
+import os
 from testr.packages import make_regress_files
 
 regress_files = ['out/index.rst',
@@ -6,6 +7,7 @@ regress_files = ['out/index.rst',
                  'out/temperatures.dat']
 
 clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', '')]}
+         'out/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/acisfp_check/post_regress_head.py
+++ b/packages/acisfp_check/post_regress_head.py
@@ -1,0 +1,13 @@
+import os
+from testr.packages import make_regress_files
+
+regress_files = ['headout/index.rst',
+                 'headout/run.dat',
+                 'headout/states.dat',
+                 'headout/temperatures.dat']
+
+clean = {'headout/index.rst': [(r'^Run time.*', '')],
+         'headout/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
+
+make_regress_files(regress_files, clean=clean)

--- a/packages/acisfp_check/test_regress.sh
+++ b/packages/acisfp_check/test_regress.sh
@@ -1,4 +1,6 @@
 acisfp_check \
    --outdir=out \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
-   --run-start=2018:142
+   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
+   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
+   --state-builder=sql \
+   --run-start=2019:135

--- a/packages/acisfp_check/test_regress_head.sh
+++ b/packages/acisfp_check/test_regress_head.sh
@@ -1,0 +1,4 @@
+acisfp_check \
+   --outdir=headout \
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142

--- a/packages/dea_check/post_check_logs.py
+++ b/packages/dea_check/post_check_logs.py
@@ -3,5 +3,6 @@ from testr.packages import check_files
 check_files('test_*.log', ['warning', 'error'],
             allows=['1% quantile value of',
                     '99% quantile value of',
-                    'in output at out',
+                    'validation warning\(s\) in output',
+                    'AstropyDeprecationWarning: headout/states.dat already exists.',
                     'AstropyDeprecationWarning: out/states.dat already exists.'])

--- a/packages/dea_check/post_regress.py
+++ b/packages/dea_check/post_regress.py
@@ -6,8 +6,9 @@ regress_files = ['out/index.rst',
                  'out/states.dat',
                  'out/temperatures.dat']
 
-clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', ''),
+clean = {'out/index.rst': [(r'^Run time.*', ''),
+                           ('Load directory.*', '')],
+         'out/run.dat': [(r'#.*run at.*', ''),
                          (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/dea_check/post_regress.py
+++ b/packages/dea_check/post_regress.py
@@ -1,3 +1,4 @@
+import os
 from testr.packages import make_regress_files
 
 regress_files = ['out/index.rst',
@@ -6,6 +7,7 @@ regress_files = ['out/index.rst',
                  'out/temperatures.dat']
 
 clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', '')]}
+         'out/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/dea_check/post_regress_head.py
+++ b/packages/dea_check/post_regress_head.py
@@ -1,0 +1,13 @@
+import os
+from testr.packages import make_regress_files
+
+regress_files = ['headout/index.rst',
+                 'headout/run.dat',
+                 'headout/states.dat',
+                 'headout/temperatures.dat']
+
+clean = {'headout/index.rst': [(r'^Run time.*', '')],
+         'headout/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
+
+make_regress_files(regress_files, clean=clean)

--- a/packages/dea_check/test_regress.sh
+++ b/packages/dea_check/test_regress.sh
@@ -1,4 +1,6 @@
 dea_check \
    --outdir=out \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
-   --run-start=2018:142
+   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
+   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
+   --state-builder=sql \
+   --run-start=2019:135

--- a/packages/dea_check/test_regress_head.sh
+++ b/packages/dea_check/test_regress_head.sh
@@ -1,0 +1,4 @@
+dea_check \
+   --outdir=headout \
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142

--- a/packages/dpa_check/post_check_logs.py
+++ b/packages/dpa_check/post_check_logs.py
@@ -5,5 +5,6 @@ check_files('test_*.log', ['warning', 'error'],
                     '1dpamzt violates planning limit of 35.50 deg',
                     '50% quantile value of',
                     '99% quantile value of',
-                    'in output at out',
-                    'AstropyDeprecationWarning: out/states.dat already exists.'])
+                    'validation warning\(s\) in output',
+                    'AstropyDeprecationWarning: out/states.dat already exists.',
+                    'AstropyDeprecationWarning: headout/states.dat already exists.'])

--- a/packages/dpa_check/post_regress.py
+++ b/packages/dpa_check/post_regress.py
@@ -6,8 +6,9 @@ regress_files = ['out/index.rst',
                  'out/states.dat',
                  'out/temperatures.dat']
 
-clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', ''),
+clean = {'out/index.rst': [(r'^Run time.*', ''),
+                           ('Load directory.*', '')],
+         'out/run.dat': [(r'#.*run at.*', ''),
                          (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/dpa_check/post_regress.py
+++ b/packages/dpa_check/post_regress.py
@@ -1,3 +1,4 @@
+import os
 from testr.packages import make_regress_files
 
 regress_files = ['out/index.rst',
@@ -6,6 +7,7 @@ regress_files = ['out/index.rst',
                  'out/temperatures.dat']
 
 clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', '')]}
+         'out/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/dpa_check/post_regress_head.py
+++ b/packages/dpa_check/post_regress_head.py
@@ -1,0 +1,13 @@
+import os
+from testr.packages import make_regress_files
+
+regress_files = ['headout/index.rst',
+                 'headout/run.dat',
+                 'headout/states.dat',
+                 'headout/temperatures.dat']
+
+clean = {'headout/index.rst': [(r'^Run time.*', '')],
+         'headout/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
+
+make_regress_files(regress_files, clean=clean)

--- a/packages/dpa_check/test_regress.sh
+++ b/packages/dpa_check/test_regress.sh
@@ -1,4 +1,6 @@
 dpa_check \
    --outdir=out \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
-   --run-start=2018:142
+   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
+   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
+   --state-builder=sql \
+   --run-start=2019:135

--- a/packages/dpa_check/test_regress_head.sh
+++ b/packages/dpa_check/test_regress_head.sh
@@ -1,0 +1,4 @@
+dpa_check \
+   --outdir=headout \
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142

--- a/packages/psmc_check/post_check_logs.py
+++ b/packages/psmc_check/post_check_logs.py
@@ -4,5 +4,6 @@ check_files('test_*.log', ['warning', 'error'],
             allows=['1% quantile value of',
                     '50% quantile value of',
                     '99% quantile value of',
-                    'in output at out',
-                    'AstropyDeprecationWarning: out/states.dat already exists.'])
+                    'validation warning\(s\) in output',
+                    'AstropyDeprecationWarning: out/states.dat already exists.',
+                    'AstropyDeprecationWarning: headout/states.dat already exists.'])

--- a/packages/psmc_check/post_regress.py
+++ b/packages/psmc_check/post_regress.py
@@ -6,8 +6,9 @@ regress_files = ['out/index.rst',
                  'out/states.dat',
                  'out/temperatures.dat']
 
-clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', ''),
+clean = {'out/index.rst': [(r'^Run time.*', ''),
+                           ('Load directory.*', '')],
+         'out/run.dat': [(r'#.*run at.*', ''),
                          (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/psmc_check/post_regress.py
+++ b/packages/psmc_check/post_regress.py
@@ -1,3 +1,4 @@
+import os
 from testr.packages import make_regress_files
 
 regress_files = ['out/index.rst',
@@ -6,6 +7,7 @@ regress_files = ['out/index.rst',
                  'out/temperatures.dat']
 
 clean = {'out/index.rst': [(r'^Run time.*', '')],
-         'out/run.dat': [(r'#.*py run at.*', '')]}
+         'out/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/psmc_check/post_regress_head.py
+++ b/packages/psmc_check/post_regress_head.py
@@ -1,0 +1,13 @@
+import os
+from testr.packages import make_regress_files
+
+regress_files = ['headout/index.rst',
+                 'headout/run.dat',
+                 'headout/states.dat',
+                 'headout/temperatures.dat']
+
+clean = {'headout/index.rst': [(r'^Run time.*', '')],
+         'headout/run.dat': [(r'#.*py run at.*', ''),
+                         (os.environ['SKA'], '')]}
+
+make_regress_files(regress_files, clean=clean)

--- a/packages/psmc_check/test_regress.sh
+++ b/packages/psmc_check/test_regress.sh
@@ -1,4 +1,6 @@
 psmc_check \
    --outdir=out \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
-   --run-start=2018:142
+   --oflsdir=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa \
+   --nlet_file=${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa/NonLoadTrackedEvents.txt \
+   --state-builder=sql \
+   --run-start=2019:135

--- a/packages/psmc_check/test_regress_head.sh
+++ b/packages/psmc_check/test_regress_head.sh
@@ -1,0 +1,4 @@
+psmc_check \
+   --outdir=headout \
+   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --run-start=2018:142

--- a/packages/starcheck/post_regress.py
+++ b/packages/starcheck/post_regress.py
@@ -1,8 +1,6 @@
 from testr.packages import make_regress_files
 
 regress_files = ['starcheck.txt',
-                 'starcheck/ccd_temperature.png',
-                 'starcheck/stars_18125.png',
                  'starcheck/pcad_att_check.txt']
 
 clean = {'starcheck.txt': [(r'\s*Run on.*[\n\r]*', '')]}

--- a/packages/starcheck/post_regress.py
+++ b/packages/starcheck/post_regress.py
@@ -1,8 +1,11 @@
+import os
 from testr.packages import make_regress_files
 
 regress_files = ['starcheck.txt',
                  'starcheck/pcad_att_check.txt']
 
-clean = {'starcheck.txt': [(r'\s*Run on.*[\n\r]*', '')]}
+clean = {'starcheck.txt': [(r'\s*Run on.*[\n\r]*', ''),
+                           (os.environ['SKA'], '')],
+         'starcheck/pcad_att_check.txt': [(os.environ['SKA'], '')]}
 
 make_regress_files(regress_files, clean=clean)

--- a/packages/starcheck/test_regress.sh
+++ b/packages/starcheck/test_regress.sh
@@ -1,3 +1,1 @@
-# Always run flight starcheck, this is not for testing dev starcheck itself.
-
-${SKA}/bin/starcheck -dir ${SKA}/data/starcheck/test_loads/2016/SEP0516/oflsb
+${SKA}/bin/starcheck -dir ${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa


### PR DESCRIPTION
Update starcheck and acis regress outputs

These changes use a more atomic 'ska_testr' data area for source data for running starcheck and add additional acis checker tests compatible with that area.  The idea is that can be more portable (GRETA etc) for running the tests, though I haven't run on GRETA just yet.

The new ska_testr data area (which is presently just a test load with a few ACIS-specific files copied into it) would need to be syn'c or installed as a tarball.  Other ideas welcome in that regard.

With regard to portability, I also updated the acis regression tests to run twice by default, once in the more portable setup (that cut-down test load area and with the 'sql' state builder) and once in a way that is most like what ACIS uses in load review (against a dir in /data/acis and with the 'acis' state builder).  The regress test that will only run on HEAD LAN now has 'head' in the file name so it can be filtered easily on non-HEAD.

