### PR TITLE
Remove Ska.ParseCM from testing

### DIFF
--- a/packages/Ska.ParseCM/post_check_logs.py
+++ b/packages/Ska.ParseCM/post_check_logs.py
@@ -1,3 +1,0 @@
-from testr.packages import check_files
-
-check_files('test_*.log', ['warning', 'error'])

--- a/packages/Ska.ParseCM/test_unit_git.sh
+++ b/packages/Ska.ParseCM/test_unit_git.sh
@@ -1,5 +1,0 @@
-GIT=`PATH=/usr/bin:$PATH which git`
-$GIT clone ${TESTR_PACKAGES_REPO}/${TESTR_PACKAGE}
-cd ${TESTR_PACKAGE}
-$GIT checkout master
-py.test test.py -v -s


### PR DESCRIPTION
Since Ska.ParseCM is deprecated we can stop testing it.

This has practical benefit because tests are failing in shiny, so rather than spend time updating the tests, we can just stop running them.

Note that the tests use unittest, only run on HEAD, and have very low coverage. We are not losing much here.