### PR TITLE
Fix regression testing and post_check to work with modern kadi

### DIFF
--- a/packages/kadi/post_check_logs.py
+++ b/packages/kadi/post_check_logs.py
@@ -1,7 +1,9 @@
 from testr.packages import check_files
 
 check_files('test_*.log', ['warning', 'error'],
-            allows=['/kadi/settings.py:\d\d: UserWarning:',
-                    'warnings.warn\(message\)',
+            allows=[r'/kadi/settings.py:\d\d: UserWarning:',
+                    r'warnings.warn\(message\)',
                     'Unable to change file mode',
+                    'unable to get COBSRQID',
+                    'alter_validators_add_error_messages',
                     'Coarse OBC'])

--- a/packages/kadi/test_regress_long.sh
+++ b/packages/kadi/test_regress_long.sh
@@ -2,24 +2,18 @@
 
 GIT=`PATH=/usr/bin:$PATH which git`
 $GIT clone ${TESTR_PACKAGES_REPO}/kadi
-cd kadi
-# For now just use master.  See https://github.com/sot/kadi/issues/84
-#
-# VERSION=`python -c "import kadi; print(kadi.__version__)"`
-# git checkout $VERSION
-#
-cp manage.py update_events update_cmds ltt_bads.dat ../
-cd ..
+cp kadi/manage.py ./
 rm -rf kadi
 
 export KADI=$PWD
-./manage.py syncdb --noinput
+./manage.py makemigrations --no-input events
+./manage.py migrate --no-input
 
 START='2015:001'
 STOP='2015:030'
 
-./update_events --start=$START --stop=$STOP
-./update_cmds --start=$START --stop=$STOP
+kadi_update_events --start=$START --stop=$STOP
+kadi_update_cmds --start=$START --stop=$STOP
 
 # Write event and commands data using test database
 ./write_events_cmds.py --start=$START --stop=$STOP --data-root=events_cmds


### PR DESCRIPTION
## Description

This fixes the kadi regression testing.

## Testing

- [x] Functional testing (shiny)
- [x] Functional testing (flight)

Gives all `pass` on MacOS