### PR TITLE
Ignore FutureWarning in Ska.ParseCM

### DIFF
--- a/packages/Chandra.cmd_states/test_unit.py
+++ b/packages/Chandra.cmd_states/test_unit.py
@@ -1,2 +1,11 @@
 import testr
+import warnings
+
+# Importing Chandra.cmd_states triggers a FutureWarning from the deprecated
+# Ska.ParseCM being imported. Chandra.cmd_states is itself deprecated, so
+# just hide that particular warning in testing.
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore', FutureWarning)
+    import Ska.ParseCM  # noqa
+
 testr.testr()


### PR DESCRIPTION
## Description

Importing Chandra.cmd_states triggers a FutureWarning from the deprecated Ska.ParseCM being imported. Chandra.cmd_states is itself deprecated, so just hide that particular warning in testing.

## Testing

Ran `run_testr --include Chandra.cmd_states` in shiny and got a clean `pass`.
