### PR TITLE
Fix literal compare SyntaxWarning

### DIFF
--- a/packages/Ska.engarchive/compare_values.py
+++ b/packages/Ska.engarchive/compare_values.py
@@ -56,7 +56,7 @@ def compare_msid(msid, stat):
 
             # Do not explicitly test bads, this is done implicitly by virtue of
             # the bad filtering already applied.
-            if colname is 'bads':
+            if colname == 'bads':
                 continue
 
             # Extend the colname for reporting purposes


### PR DESCRIPTION
Leftover from the early days of not knowing Python.