### PR TITLE
Fix problem in kadi regress

### DIFF
--- a/packages/kadi/test_regress.sh
+++ b/packages/kadi/test_regress.sh
@@ -3,23 +3,22 @@
 if [ ! -d "$SKA/data/mpcrit1/mplogs" ]
 then
   echo "Directory $SKA/data/mpcrit1/mplogs not found, skipping regression test"
-  exit 0
+else
+  GIT=`PATH=/usr/bin:$PATH which git`
+  $GIT clone ${TESTR_PACKAGES_REPO}/kadi
+  cp kadi/manage.py ./
+  rm -rf kadi
+
+  export KADI=$PWD
+  ./manage.py makemigrations --no-input events
+  ./manage.py migrate --no-input
+
+  START='2015:001:12:00:00'
+  STOP='2015:030:12:00:00'
+
+  kadi_update_events --start=$START --stop=$STOP
+  kadi_update_cmds --start=$START --stop=$STOP
+
+  # Write event and commands data using test database
+  ./compare_values.py --start=$START --stop=$STOP --data-root=events_cmds
 fi
-
-GIT=`PATH=/usr/bin:$PATH which git`
-$GIT clone ${TESTR_PACKAGES_REPO}/kadi
-cp kadi/manage.py ./
-rm -rf kadi
-
-export KADI=$PWD
-./manage.py makemigrations --no-input events
-./manage.py migrate --no-input
-
-START='2015:001:12:00:00'
-STOP='2015:030:12:00:00'
-
-kadi_update_events --start=$START --stop=$STOP
-kadi_update_cmds --start=$START --stop=$STOP
-
-# Write event and commands data using test database
-./compare_values.py --start=$START --stop=$STOP --data-root=events_cmds


### PR DESCRIPTION
Apparently `pexpect` doesn't like `exit 0` within the test script.