### PR TITLE
Prevent writing migrations into environment

### DIFF
--- a/packages/kadi/compare_values.py
+++ b/packages/kadi/compare_values.py
@@ -75,6 +75,7 @@ def compare_outputs():
 
     has_diff = False
     for file_a, file_b in zip(files_a, files_b):
+        print(f'Comparing files {file_a} {file_b}')
         lines_a = file_a.read_text().splitlines()
         lines_b = file_b.read_text().splitlines()
 

--- a/packages/kadi/test_regress.sh
+++ b/packages/kadi/test_regress.sh
@@ -4,14 +4,16 @@ if [ ! -d "$SKA/data/mpcrit1/mplogs" ]
 then
   echo "Directory $SKA/data/mpcrit1/mplogs not found, skipping regression test"
 else
+  export KADI=$PWD
+
   GIT=`PATH=/usr/bin:$PATH which git`
   $GIT clone ${TESTR_PACKAGES_REPO}/kadi
-  cp kadi/manage.py ./
-  rm -rf kadi
 
-  export KADI=$PWD
+  cd kadi
   ./manage.py makemigrations --no-input events
   ./manage.py migrate --no-input
+  cd ..
+  rm -rf kadi
 
   START='2015:001:12:00:00'
   STOP='2015:030:12:00:00'


### PR DESCRIPTION
The previous version was writing into the installed Python environment site-packages/kadi. This was accidentally working in testing done by same user that created the environment, but failed on production HEAD linux.

This fix does the migrations (creating initial empty database) using a local version of kadi on master but then does the update using the installed version.