### PR TITLE
Update ACIS LR tests to pass on standalone also

### DIFF
--- a/packages/acisfp_check/test_regress_head.sh
+++ b/packages/acisfp_check/test_regress_head.sh
@@ -1,4 +1,7 @@
+export ALLOW_NONSTANDARD_OFLSDIR=1
+
 acisfp_check \
    --outdir=headout \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --oflsdir=${SKA}/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --nlet_file=${SKA}/data/acis/LoadReviews/NonLoadTrackedEvents.txt \
    --run-start=2018:142

--- a/packages/dea_check/test_regress_head.sh
+++ b/packages/dea_check/test_regress_head.sh
@@ -1,4 +1,7 @@
+export ALLOW_NONSTANDARD_OFLSDIR=1
+
 dea_check \
    --outdir=headout \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --oflsdir=${SKA}/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --nlet_file=${SKA}/data/acis/LoadReviews/NonLoadTrackedEvents.txt \
    --run-start=2018:142

--- a/packages/dpa_check/test_regress_head.sh
+++ b/packages/dpa_check/test_regress_head.sh
@@ -1,4 +1,7 @@
+export ALLOW_NONSTANDARD_OFLSDIR=1
+
 dpa_check \
    --outdir=headout \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --oflsdir=${SKA}/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --nlet_file=${SKA}/data/acis/LoadReviews/NonLoadTrackedEvents.txt \
    --run-start=2018:142

--- a/packages/psmc_check/test_regress_head.sh
+++ b/packages/psmc_check/test_regress_head.sh
@@ -1,4 +1,7 @@
+export ALLOW_NONSTANDARD_OFLSDIR=1
+
 psmc_check \
    --outdir=headout \
-   --oflsdir=/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --oflsdir=${SKA}/data/acis/LoadReviews/2018/MAY2818/oflsa \
+   --nlet_file=${SKA}/data/acis/LoadReviews/NonLoadTrackedEvents.txt \
    --run-start=2018:142


### PR DESCRIPTION
With these updates the tests all pass now on standalone.  Requires https://github.com/acisops/acis_thermal_check/pull/35 and https://github.com/acisops/backstop_history/pull/14.

Tested on my Mac with shiny rc11.