### PR TITLE
Make starcheck regression test work standalone

### DIFF
--- a/packages/starcheck/test_regress.sh
+++ b/packages/starcheck/test_regress.sh
@@ -1,1 +1,1 @@
-${SKA}/bin/starcheck -dir ${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa
+starcheck -dir ${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa


### PR DESCRIPTION
## Description

The starcheck regression test was assuming that `$SKA` is the environment root, which is not the case on a standalone platform. In modern Ska3, `starcheck` is in the path so just use that.

## Testing (in shiny)

`run_testr --include starcheck`

- [x] MacoS
- [x] HEAD linux (kady)
