### PR TITLE
Ignore ErfaWarnings from astropy in acis checkers

### DIFF
--- a/packages/acisfp_check/post_check_logs.py
+++ b/packages/acisfp_check/post_check_logs.py
@@ -7,4 +7,6 @@ check_files('test_*.log', ['warning', 'error'],
                     'fptemp violates ACIS-I limit',
                     'fptemp violates FP-sensitive limit',
                     'AstropyDeprecationWarning: out/states.dat already exists.',
-                    'AstropyDeprecationWarning: headout/states.dat already exists.'])
+                    'AstropyDeprecationWarning: headout/states.dat already exists.',
+                    'ErfaWarning: ERFA function "dtf2d" yielded 2 of "dubious year',
+                    'ErfaWarning: ERFA function "utctai" yielded 2 of "dubious year'])

--- a/packages/psmc_check/post_check_logs.py
+++ b/packages/psmc_check/post_check_logs.py
@@ -6,4 +6,6 @@ check_files('test_*.log', ['warning', 'error'],
                     '99% quantile value of',
                     'validation warning\(s\) in output',
                     'AstropyDeprecationWarning: out/states.dat already exists.',
-                    'AstropyDeprecationWarning: headout/states.dat already exists.'])
+                    'AstropyDeprecationWarning: headout/states.dat already exists.',
+                    'ErfaWarning: ERFA function "dtf2d" yielded 2 of "dubious year',
+                    'ErfaWarning: ERFA function "utctai" yielded 2 of "dubious year'])


### PR DESCRIPTION
Ignore ErfaWarnings from astropy in acis checkers

