### PR TITLE
Use the current kadi version in tests, even if it is from github.

### DIFF
--- a/packages/kadi/test_regress.sh
+++ b/packages/kadi/test_regress.sh
@@ -12,7 +12,7 @@ else
   $GIT clone ${TESTR_PACKAGES_REPO}/kadi
 
   cd kadi
-  git co $KADI_VERSION
+  $GIT checkout $KADI_VERSION
   ./manage.py makemigrations --no-input events
   ./manage.py migrate --no-input
   cd ..

--- a/packages/kadi/test_regress.sh
+++ b/packages/kadi/test_regress.sh
@@ -6,10 +6,13 @@ then
 else
   export KADI=$PWD
 
+  KADI_VERSION=`python -c 'import kadi; print(kadi.__version__)'`
+
   GIT=`PATH=/usr/bin:$PATH which git`
   $GIT clone ${TESTR_PACKAGES_REPO}/kadi
 
   cd kadi
+  git co $KADI_VERSION
   ./manage.py makemigrations --no-input events
   ./manage.py migrate --no-input
   cd ..

--- a/packages/kadi/test_regress.sh
+++ b/packages/kadi/test_regress.sh
@@ -1,12 +1,23 @@
 # Get three launcher scripts manage.py update_events and update_cmds
 
+KADI_VERSION_CMD=$(cat <<- END
+import re;
+import kadi;
+m = re.search('\.dev[0-9]+\+g(?P<sha>[a-zA-Z0-9]+)', kadi.__version__);
+if m:
+    print(m.groupdict()['sha'])
+else:
+    print(kadi.__version__)
+END
+)
+
 if [ ! -d "$SKA/data/mpcrit1/mplogs" ]
 then
   echo "Directory $SKA/data/mpcrit1/mplogs not found, skipping regression test"
 else
   export KADI=$PWD
 
-  KADI_VERSION=`python -c 'import kadi; print(kadi.__version__)'`
+  KADI_VERSION=`python -c "$KADI_VERSION_CMD"`
 
   GIT=`PATH=/usr/bin:$PATH which git`
   $GIT clone ${TESTR_PACKAGES_REPO}/kadi


### PR DESCRIPTION
## Description

Currently the kadi test checks out the master branch of sot/kadi to use the `manage.py` script. This changes the test to use the version in the environment where the test is run.

## Testing

- [x] Functional testing. I ran the following:
      ```
     run_testr --include kadi
      ```
     using the `ska3-flight-2021.9rc2` environment in `/export/jgonzale/github-workflows/miniconda3-shiny`. This environment has version 5.6.0 of kadi, which should pass tests, but tests fail when using the master branch from github. The test fails with the current master, and succeeds with the changes in this PR:
- [x] I checked the script locally to make sure the regex could parse a typical version like there will be in ska3-masters when commits are added to kadi but before a release.
