### PR TITLE
Allow 50% quantile warn in dea regress output

### DIFF
--- a/packages/dea_check/post_check_logs.py
+++ b/packages/dea_check/post_check_logs.py
@@ -3,6 +3,7 @@ from testr.packages import check_files
 check_files('test_*.log', ['warning', 'error'],
             allows=['1% quantile value of',
                     '99% quantile value of',
+                    '50% quantile value of',
                     'validation warning\(s\) in output',
                     'AstropyDeprecationWarning: headout/states.dat already exists.',
                     'AstropyDeprecationWarning: out/states.dat already exists.'])


### PR DESCRIPTION
## Description

Allow 50% quantile warn in dea regress output

## Testing

- [x] Functional testing

I just ran the dea_check tests from HEAD and they PASS with this change
