### PR TITLE
Use the explicit OCAT URL when checking whether CDA is accessible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+release_tests

--- a/packages/acisfp_check/skip.yml
+++ b/packages/acisfp_check/skip.yml
@@ -14,13 +14,13 @@
 'test_regress.sh':
   check_func: not has_internet
   check_args:
-    - https://cda.cfa.harvard.edu
+    - https://cda.cfa.harvard.edu/srservices/ocatDetails.do?format=text&obsid=5438
   reason: No access to CDA
 
 'post_regress.py':
   check_func: not has_internet
   check_args:
-    - https://cda.cfa.harvard.edu
+    - https://cda.cfa.harvard.edu/srservices/ocatDetails.do?format=text&obsid=5438
   reason: No access to CDA
 
 '*':


### PR DESCRIPTION
## Description

This is to skip some tests when CDA is not accessible.

## Testing

- [ ] Functional testing
