### PR TITLE
Remove hard limits from dpa check_files allows

### DIFF
--- a/packages/dpa_check/post_check_logs.py
+++ b/packages/dpa_check/post_check_logs.py
@@ -2,10 +2,10 @@ from testr.packages import check_files
 
 check_files('test_*.log', ['warning', 'error'],
             allows=['1% quantile value of',
-                    '1dpamzt violates planning limit of 35.50 deg',
+                    '1dpamzt violates planning limit',
                     '50% quantile value of',
                     '99% quantile value of',
-                    '1dpamzt violates zero-feps limit of 12.00 degC',
+                    '1dpamzt violates zero-feps limit',
                     'validation warning\(s\) in output',
                     'AstropyDeprecationWarning: out/states.dat already exists.',
                     'AstropyDeprecationWarning: headout/states.dat already exists.'])


### PR DESCRIPTION
## Description

Remove hard limits from dpa check_files allows

## Testing

- [x] Functional testing

With this updated `allows`, the "1dpamzt violates zero-feps limit of 13.00 degC" warnings that we see with chandra_models 3.40.1 are ignored but the dpa_check is still exercised.

