### PR TITLE
Stop updating cmds v1 archive for regress test

### DIFF
--- a/packages/kadi/test_regress.sh
+++ b/packages/kadi/test_regress.sh
@@ -37,7 +37,6 @@ else
   STOP='2020:189:00:00:00'
 
   kadi_update_events --start=$START --stop=$STOP
-  kadi_update_cmds --start=$START --stop=$STOP
 
   # Write event and commands data using test database
   ./compare_values.py --start=$START --stop=$STOP --data-root=events_cmds


### PR DESCRIPTION
## Description

Stop updating cmds v1 archive for regress test.

## Testing

- [x] Functional testing - kadi tests still worked. 

I confirmed that the cmds v1 script was not called by reviewing the log.  Before this PR:
```
ska3-jeanconn-fido> grep update_cmds_v1.py test_regress.log 
2022-10-04 09:40:39,034 Running: /proj/sot/ska3/flight/lib/python3.8/site-packages/kadi/scripts/update_cmds_v1.py
```
After this PR.
```
ska3-jeanconn-fido> grep update_cmds_v1.py test_regress.log 
ska3-jeanconn-fido> 
```

I note that I tested against flight kadi but it shouldn't matter in the context of this change.
