### PR TITLE
Add an exception to pattern matching in starcheck/post_check_logs.py

### DIFF
--- a/packages/starcheck/post_check_logs.py
+++ b/packages/starcheck/post_check_logs.py
@@ -1,3 +1,7 @@
 from testr.packages import check_files
 
-check_files('test_*.log', ['warning', 'error'])
+check_files(
+    'test_*.log',
+    ['warning', 'error'],
+    allows=["Reading Maneuver Error file"]
+)


### PR DESCRIPTION
## Description

The change in this PR is to prevent a failure in `starcheck/post_check_logs.py` caused by the occurrence of the string `Reading Maneuver Error file`

## Testing

- [x] `post_check_logs.py` succeeds in an environment with the current starcheck master and this branch of ska_testr (it fails with ska_testr@master):

   ```
   run_testr --include starcheck
   ```