### PR TITLE
skip find_attitude tests on windows

### DIFF
--- a/packages/find_attitude/skip.yml
+++ b/packages/find_attitude/skip.yml
@@ -1,0 +1,4 @@
+'*':
+  check_func: is_windows
+  reason: "find_attitude tests are skipped on Windows (Sherpa is not installed)"
+


### PR DESCRIPTION

## Description

Sherpa is not installed on Windows, but find_attitude tests require it, so I added a corresponding skip file.


## Testing

- [ ] Functional testing

Fixes #