### PR TITLE
Add new warning ignores that appear in testr and are not ours

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,11 @@ filterwarnings =
 
     ignore: the imp module is deprecated
 
+    ignore: pkg_resources is deprecated as an API
+    ignore: Deprecated call to `pkg_resources
+    ignore: 'locale.getdefaultlocale' is deprecated
+    ignore: 'cgi' is deprecated
+
 # these are convenient to have around to configure logging from pytest
 log_cli = False
 log_cli_level = DEBUG

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,8 +16,10 @@ filterwarnings =
 
     ignore: the imp module is deprecated
 
+    # These are caused by sherpa
     ignore: pkg_resources is deprecated as an API
     ignore: Deprecated call to `pkg_resources
+    # These are in django
     ignore: 'locale.getdefaultlocale' is deprecated
     ignore: 'cgi' is deprecated
 


### PR DESCRIPTION
## Description

This adds a few warnings to ignore in `pytest.ini`. I will also remove older warning ignores that are not required anymore.

## Testing

- [ ] Functional testing

Fixes #