### PR TITLE
ignore numpy `alltrue` is deprecated warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,8 @@ filterwarnings =
     # These are in django
     ignore: 'locale.getdefaultlocale' is deprecated
     ignore: 'cgi' is deprecated
+    # This one is in pytables
+    ignore: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0
 
 # these are convenient to have around to configure logging from pytest
 log_cli = False


### PR DESCRIPTION
## Description

After downgrading pytables, now we get a deprecation warning. This just ignores that. Something to keep in mind in /skot/skare3/issues/1295.

## Testing

- [ ] Functional testing

Fixes #