### PR TITLE
Stop apparently-benign warns from acis tests

### DIFF
--- a/packages/acisfp_check/post_check_logs.py
+++ b/packages/acisfp_check/post_check_logs.py
@@ -10,4 +10,5 @@ check_files('test_*.log', ['warning', 'error'],
                     'AstropyDeprecationWarning: out/states.dat already exists.',
                     'AstropyDeprecationWarning: headout/states.dat already exists.',
                     'ErfaWarning: ERFA function "dtf2d" yielded 2 of "dubious year',
-                    'ErfaWarning: ERFA function "utctai" yielded 2 of "dubious year'])
+                    'ErfaWarning: ERFA function "utctai" yielded 2 of "dubious year',
+                    'RuntimeWarning: invalid value encountered in cast'])

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,10 +29,6 @@ filterwarnings =
     # matplotlib and acis_thermal_check
     ignore: Conversion of an array with ndim > 0 to a scalar is deprecated
 
-    # acis_thermal_check
-    ignore: RuntimeWarning: invalid value encountered in cast
-
-
 # these are convenient to have around to configure logging from pytest
 log_cli = False
 log_cli_level = DEBUG

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,6 +26,13 @@ filterwarnings =
     ignore: `alltrue` is deprecated as of NumPy 1.25.0
     ignore: `sometrue` is deprecated as of NumPy 1.25.0
 
+    # matplotlib and acis_thermal_check
+    ignore: Conversion of an array with ndim > 0 to a scalar is deprecated
+
+    # acis_thermal_check
+    ignore: RuntimeWarning: invalid value encountered in cast
+
+
 # these are convenient to have around to configure logging from pytest
 log_cli = False
 log_cli_level = DEBUG

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,9 +26,6 @@ filterwarnings =
     ignore: `alltrue` is deprecated as of NumPy 1.25.0
     ignore: `sometrue` is deprecated as of NumPy 1.25.0
 
-    # matplotlib and acis_thermal_check
-    ignore: Conversion of an array with ndim > 0 to a scalar is deprecated
-
 # these are convenient to have around to configure logging from pytest
 log_cli = False
 log_cli_level = DEBUG


### PR DESCRIPTION
## Description

Stop apparently-benign warns from acis tests.

I'd like to get these out of the daily ska3 testing warnings.

## Testing

- [x] Functional testing

I've just run to get all "pass" values from acisfp_check and acis_thermal_check on linux from ska3-flight.
