### PR TITLE
Use proseco agasc 1p7 for starcheck 2019 regress run test

### DIFF
--- a/packages/starcheck/test_regress.sh
+++ b/packages/starcheck/test_regress.sh
@@ -1,1 +1,1 @@
-starcheck -dir ${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa
+env AGASC_HDF5_FILE=proseco_agasc_1p7.h5 starcheck -dir ${SKA}/data/ska_testr/test_loads/2019/MAY2019/oflsa


### PR DESCRIPTION
## Description

Use proseco agasc 1p7 for starcheck 2019 regress run test

## Testing

- [x] Functional testing

Without this fix, the starcheck regress test will fail due to a star that is no longer in the proseco agasc
```
'error' matched at test_regress.log:185 :: ValueError: cannot include star id=691150208 that is not a valid star in the ACA field of view
```
With this fix, the starcheck run test passes.
