### PR TITLE
Handle kadi warning from 7.11.0 agasc test

### DIFF
--- a/packages/kadi/post_check_logs.py
+++ b/packages/kadi/post_check_logs.py
@@ -10,4 +10,5 @@ check_files('test_*.log', ['warning', 'error'],
                     'negative event duration',
                     'Coarse OBC',
                     'no starcat for obsid 0',
-                    'from sot/matching-blocks-error-message'])
+                    'from sot/matching-blocks-error-message',
+                    'star idx 11 not found in obsid 2576'])


### PR DESCRIPTION
## Description

Handle kadi warning from 7.11.0 agasc test

## Testing

- [x] Functional testing

Fixes 

```
ValueError: Found matches in check_files:
'warning' matched at test_unit.log:53 :: ../../../../../../../home/jconnelly/git/ska_testr/commands/tests/test_commands.py::test_get_starcat_only_agasc1p8 2024-07-23 13:21:07,533 set_star_ids: WARNING: star idx 11 not found in obsid 2576 at 2002:365:17:06:40.050
```