### PR TITLE
Add 50th to logcheck/exception list for acisfp_check

### DIFF
--- a/packages/acisfp_check/post_check_logs.py
+++ b/packages/acisfp_check/post_check_logs.py
@@ -2,6 +2,7 @@ from testr.packages import check_files
 
 check_files('test_*.log', ['warning', 'error'],
             allows=['1% quantile value of',
+                    '50% quantile value of',
                     '99% quantile value of',
                     'validation warning\(s\) in output',
                     'fptemp violates ACIS-I limit',


### PR DESCRIPTION
## Description

Add the 50th quantile to the log check exceptions list.  Looks like we need this now with chandra_models 3.55 and old week used for "did the model run" regression run in ska_testr for acisfp_check .

Fixes

```
Running python post_check_logs.py script
Traceback (most recent call last):
  File "/proj/sot/ska/jeanproj/git/ska_testr/outputs/logs/Linux_2024-09-16T17-23-29_2024.7-65fc1c7_fido.cfa.harvard.edu/acisfp_check/post_check_logs.py", line 3, in <module>
    check_files('test_*.log', ['warning', 'error'],
  File "/proj/sot/ska3/flight/lib/python3.11/site-packages/testr/packages.py", line 691, in check_files
    raise ValueError('Found matches in check_files:\n{}'.format('\n'.join(matches)))
ValueError: Found matches in check_files:
'warning' matched at test_regress.log:43 :: acis_thermal_check: [WARNING  ] FPTEMP 50% quantile value of 1.8 exceeds limit of 1.00
Running python post_regress.py script
Running python post_regress_head.py script
****************************************
*** acisfp_check Test Summary        ***
*** test_regress.sh      pass        ***
*** test_regress_head.sh pass        ***
*** post_check_logs.py   FAIL        ***
*** post_regress.py      pass        ***
*** post_regress_head.py pass        ***
****************************************
```

- [x] Functional testing

```
ska3-jeanconn-fido> git rev-parse HEAD
fa8d07ebbd55374a79456822a1b4d4f53b072a5b
...
Running python post_check_logs.py script
Running python post_regress.py script
Running python post_regress_head.py script
****************************************
*** acisfp_check Test Summary        ***
*** test_regress.sh      pass        ***
*** test_regress_head.sh pass        ***
*** post_check_logs.py   pass        ***
*** post_regress.py      pass        ***
*** post_regress_head.py pass        ***
****************************************
```
