### PR TITLE
Ignore DeprecationWarnings about pyt/multithreaded deadlocks

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,10 @@ filterwarnings =
 
     ignore: The 'strip_cdata' option of HTMLParser
 
+    # Should probably fix this by stopping using pty in mica update l1 archive
+    ignore: This process \(pid=\d+\) is multi-threaded
+
+
 # these are convenient to have around to configure logging from pytest
 log_cli = False
 log_cli_level = DEBUG


### PR DESCRIPTION
## Description

Ignore DeprecationWarnings about pyt/multithreaded deadlocks


## Testing

- [x] Functional testing

```
***               mica              test_unit.py   pass ***
***               mica        post_check_logs.py   pass ***
```

Without this modification, the mica l1 update archive test gets this deprecation warning.  I think @javierggt's plan to remove pexpect in https://github.com/sot/ska_shell/pull/31 is great, but until then the warnings may cause me to miss legitimate regressions.