### PR TITLE
Use fetch from cheta in ska_testr compare_values

### DIFF
--- a/packages/cheta/compare_values.py
+++ b/packages/cheta/compare_values.py
@@ -10,7 +10,7 @@ as ``data``.
 import os
 
 import numpy as np
-from Ska.engarchive import fetch
+from cheta import fetch
 import argparse
 
 


### PR DESCRIPTION
## Description
Use fetch from cheta instead of Ska.engarchive in ska_testr compare_values

See https://chandramission.slack.com/archives/G01LN40AXPG/p1754319652317989 for the driver and rationale behind this fix.

## Testing

- [x] Functional testing

In an HEAD linux environment with cheta at https://github.com/sot/cheta/commit/7cae37d9687f38ac52e57b44613df394193cb875 tests pass with this one-line change

```
***              cheta test_make_archive_long.sh   pass ***
***              cheta         test_namespace.py   pass ***
***              cheta              test_unit.py   pass ***
***              cheta        post_check_logs.py   pass ***
```
