### PR TITLE
exclude warning issued in kadi.observations._set_star_id during an ex…

### DIFF
--- a/packages/kadi/post_check_logs.py
+++ b/packages/kadi/post_check_logs.py
@@ -1,13 +1,19 @@
 from testr.packages import check_files
 
-check_files('test_*.log', ['warning', 'error'],
-            allows=[r'/kadi/settings.py:\d\d: UserWarning:',
-                    r'warnings.warn\(message\)',
-                    'Unable to change file mode',
-                    'unable to get COBSRQID',
-                    'alter_validators_add_error_messages',
-                    'dropping state because of insufficent event time pad',
-                    'negative event duration',
-                    'Coarse OBC',
-                    'no starcat for obsid 0',
-                    'from sot/matching-blocks-error-message'])
+check_files(
+    "test_*.log",
+    ["warning", "error"],
+    allows=[
+        r"/kadi/settings.py:\d\d: UserWarning:",
+        r"warnings.warn\(message\)",
+        "Unable to change file mode",
+        "unable to get COBSRQID",
+        "alter_validators_add_error_messages",
+        "dropping state because of insufficent event time pad",
+        "negative event duration",
+        "Coarse OBC",
+        "no starcat for obsid 0",
+        "from sot/matching-blocks-error-message",
+        "WARNING: star idx 4 not found in obsid 28501",
+    ],
+)


### PR DESCRIPTION
## Description

This PR allows a warning that gets issued in a test that is expected to fail.


## Testing

- [ ] Functional testing

Fixes #